### PR TITLE
Fallback missing tiles to lower zooms

### DIFF
--- a/src/mahomaps/Settings.java
+++ b/src/mahomaps/Settings.java
@@ -28,6 +28,10 @@ public class Settings {
 	public static boolean bbWifi;
 	public static boolean firstLaunch = true;
 	public static int map;
+	/**
+	 * Reads "fallback" tile (scaled up) before downloading it.
+	 */
+	public static boolean readCachedBeforeDownloading = false;
 
 	public static String proxyServer = "http://nnp.nnchan.ru:80/mahoproxy.php?u=";
 
@@ -94,6 +98,7 @@ public class Settings {
 			firstLaunch = j.getBoolean("1", true);
 			usageFlags = j.getInt("tm", 0);
 			map = j.getInt("map", 0);
+			readCachedBeforeDownloading = j.getBoolean("upscale", false);
 			return true;
 		} catch (Throwable e) {
 			e.printStackTrace();
@@ -137,6 +142,7 @@ public class Settings {
 		j.put("1", firstLaunch);
 		j.put("tm", usageFlags);
 		j.put("map", map);
+		j.put("upscale", readCachedBeforeDownloading);
 		return j.toString();
 	}
 

--- a/src/mahomaps/map/TileCache.java
+++ b/src/mahomaps/map/TileCache.java
@@ -29,11 +29,13 @@ public class TileCache extends TileId {
 		Font f = Font.getFont(0, 0, 8);
 		int vo = f.getHeight();
 		g.setFont(f);
+		Image i = img;
+		if (i != null) {
+			g.drawImage(i, tx, ty, 0);
+		}
 		if (state == STATE_READY) {
-			Image i = img;
 			if (i == null) // wtf!?
 				throw new NullPointerException("Corrupted tile state!");
-			g.drawImage(i, tx, ty, 0);
 			g.setColor(0, 0, 255);
 		} else {
 			g.setGrayScale(0);

--- a/src/mahomaps/map/TileCache.java
+++ b/src/mahomaps/map/TileCache.java
@@ -38,8 +38,17 @@ public class TileCache extends TileId {
 				throw new NullPointerException("Corrupted tile state!");
 			g.setColor(0, 0, 255);
 		} else {
+			int ax = tx + 128;
+			int ay = ty + 128 - (vo / 2);
+
+			g.setGrayScale(255);
+			g.drawString(GetState(), ax + 1, ay + 1, Graphics.TOP | Graphics.HCENTER);
+			g.drawString(GetState(), ax - 1, ay + 1, Graphics.TOP | Graphics.HCENTER);
+			g.drawString(GetState(), ax + 1, ay - 1, Graphics.TOP | Graphics.HCENTER);
+			g.drawString(GetState(), ax - 1, ay - 1, Graphics.TOP | Graphics.HCENTER);
+
 			g.setGrayScale(0);
-			g.drawString(GetState(), tx + 128, ty + 128 - vo, Graphics.TOP | Graphics.HCENTER);
+			g.drawString(GetState(), ax, ay, Graphics.TOP | Graphics.HCENTER);
 		}
 		if (Settings.drawDebugInfo) {
 			g.drawRect(tx, ty, 255, 255);

--- a/src/mahomaps/map/TilesProvider.java
+++ b/src/mahomaps/map/TilesProvider.java
@@ -242,7 +242,7 @@ public class TilesProvider implements Runnable {
 		int yoff = 0;
 		while (true) {
 			zoom -= 1;
-			if (zoom == 0 || downscale >= 64)
+			if (zoom < 0 || downscale >= 64)
 				return null;
 			downscale *= 2;
 			if (x % 2 == 1)

--- a/src/mahomaps/map/TilesProvider.java
+++ b/src/mahomaps/map/TilesProvider.java
@@ -383,7 +383,10 @@ public class TilesProvider implements Runnable {
 				}
 
 				if (idleCount != cache.size() || queueChanged)
+				{
+					Thread.yield();
 					continue;
+				}
 				downloadGate.Pass();
 			}
 		} catch (InterruptedException e) {

--- a/src/mahomaps/map/TilesProvider.java
+++ b/src/mahomaps/map/TilesProvider.java
@@ -78,6 +78,10 @@ public class TilesProvider implements Runnable {
 		return s;
 	}
 
+	public String GetLocalPath() {
+		return localPath;
+	}
+
 	public TilesProvider(String lang) {
 		if (lang == null)
 			throw new NullPointerException("Language must be non-null!");

--- a/src/mahomaps/map/TilesProvider.java
+++ b/src/mahomaps/map/TilesProvider.java
@@ -214,9 +214,15 @@ public class TilesProvider implements Runnable {
 					synchronized (tc) {
 						if (img != null) {
 							tc.img = img;
+
 							// readCachedBeforeDownloading is still require server lookup
-							tc.state = tryDownloadAnyway ? TileCache.STATE_SERVER_PENDING : TileCache.STATE_READY;
-							MahoMapsApp.GetCanvas().requestRepaint();
+							if (tryDownloadAnyway) {
+								tc.state = TileCache.STATE_SERVER_PENDING;
+								downloadGate.Reset();
+							} else {
+								tc.state = TileCache.STATE_READY;
+								MahoMapsApp.GetCanvas().requestRepaint();
+							}
 						} else if (Settings.allowDownload) {
 							tc.state = TileCache.STATE_SERVER_PENDING;
 							downloadGate.Reset();

--- a/src/mahomaps/map/TilesProvider.java
+++ b/src/mahomaps/map/TilesProvider.java
@@ -235,26 +235,31 @@ public class TilesProvider implements Runnable {
 	private final Image tryLoadFallback(TileId id) {
 		final int map = id.map;
 		int zoom = id.zoom;
-		int downscale = 1;
+		int downscale = 1; // how small is required tile comparing to loaded one
 		int x = id.x;
 		int y = id.y;
-		int xoff = 0;
+		int xoff = 0; // in tile sizes
 		int yoff = 0;
 		while (true) {
 			zoom -= 1;
 			if (zoom < 0 || downscale >= 64)
 				return null;
-			downscale *= 2;
 			if (x % 2 == 1)
-				xoff += (256 / downscale);
+				xoff += downscale;
 			if (y % 2 == 1)
-				yoff += (256 / downscale);
+				yoff += downscale;
+			// at downscale of 2 above ops require 1, at 4 - 2 and so on
+			downscale *= 2;
 			x /= 2;
 			y /= 2;
 			Image raw = tryLoad(new TileId(x, y, zoom, map));
 			if (raw != null) {
-				int size = (256 / downscale);
-				Image cropped = ImageUtils.crop(raw, xoff, yoff, xoff + size, yoff + size);
+				int size = (256 / downscale); // of tile
+				// System.out.println("downscale: " + downscale + ", size: " + size);
+				// System.out.println("x: " + xoff + ", y: " + yoff);
+				int xoffp = xoff * size; // in pixels
+				int yoffp = yoff * size;
+				Image cropped = ImageUtils.crop(raw, xoffp, yoffp, xoffp + size, yoffp + size);
 				raw = null; // to free heap
 				return ImageUtils.resize(cropped, 256, 256, true, false);
 			}

--- a/src/mahomaps/map/TilesProvider.java
+++ b/src/mahomaps/map/TilesProvider.java
@@ -465,7 +465,6 @@ public class TilesProvider implements Runnable {
 			} catch (RuntimeException e1) {
 			}
 		} catch (Exception e) {
-			e.printStackTrace();
 		} catch (OutOfMemoryError e) {
 		} finally {
 			if (hc != null) {

--- a/src/mahomaps/map/TilesProvider.java
+++ b/src/mahomaps/map/TilesProvider.java
@@ -185,11 +185,18 @@ public class TilesProvider implements Runnable {
 						}
 					}
 
-					Image img = null;
-					if (Settings.cacheMode == Settings.CACHE_FS && localPath != null) {
-						img = tryLoadFromFS(tc);
-					} else if (Settings.cacheMode == Settings.CACHE_RMS) {
-						img = tryLoadFromRMS(tc);
+					Image img = tryLoad(tc);
+
+					// if tile is not cached...
+					if (img == null) {
+						// but we can't download it...
+						if (!Settings.allowDownload) {
+							// and cache lookup actually was attempted...
+							if (Settings.cacheMode != Settings.CACHE_DISABLED) {
+								// let's try lower zooms and upscale them.
+								img = tryLoadFallback(tc);
+							}
+						}
 					}
 
 					synchronized (tc) {

--- a/src/mahomaps/map/TilesProvider.java
+++ b/src/mahomaps/map/TilesProvider.java
@@ -211,6 +211,15 @@ public class TilesProvider implements Runnable {
 		}
 	}
 
+	private final Image tryLoad(TileId id) {
+		if (Settings.cacheMode == Settings.CACHE_FS && localPath != null) {
+			return tryLoadFromFS(id);
+		} else if (Settings.cacheMode == Settings.CACHE_RMS) {
+			return tryLoadFromRMS(id);
+		}
+		return null;
+	}
+
 	public void RunNetwork() {
 		try {
 			// цикл обработки

--- a/src/mahomaps/map/TilesProvider.java
+++ b/src/mahomaps/map/TilesProvider.java
@@ -642,8 +642,7 @@ public class TilesProvider implements Runnable {
 	}
 
 	private String getUrl(TileId tileId) {
-		String url = tilesUrls[tileId.map] + lang + "&x=" + tileId.x + "&y=" + tileId.y
-				+ "&z=" + tileId.zoom;
+		String url = tilesUrls[tileId.map] + lang + "&x=" + tileId.x + "&y=" + tileId.y + "&z=" + tileId.zoom;
 		if (Settings.proxyTiles && url.startsWith("https")) {
 			return Settings.proxyServer + YmapsApiBase.EncodeUrl(url);
 		}

--- a/src/mahomaps/screens/CacheManager.java
+++ b/src/mahomaps/screens/CacheManager.java
@@ -26,6 +26,8 @@ public class CacheManager extends Form implements CommandListener, ItemCommandLi
 		setCommandListener(this);
 		append(new StringItem(MahoMapsApp.text[71], getCacheType()));
 		append(new StringItem(MahoMapsApp.text[72], "" + tiles.GetCachedTilesCount()));
+		if (Settings.cacheMode == Settings.CACHE_FS)
+			append(new StringItem(MahoMapsApp.text[71], tiles.GetLocalPath()));
 		delAll.setLayout(Item.LAYOUT_NEWLINE_AFTER | Item.LAYOUT_NEWLINE_BEFORE);
 		delAll.setDefaultCommand(sel);
 		delAll.setItemCommandListener(this);

--- a/src/mahomaps/screens/SettingsScreen.java
+++ b/src/mahomaps/screens/SettingsScreen.java
@@ -27,7 +27,7 @@ public class SettingsScreen extends Form implements CommandListener {
 	private ChoiceGroup cache = new ChoiceGroup(MahoMapsApp.text[52], Choice.POPUP,
 			new String[] { MahoMapsApp.text[18], MahoMapsApp.text[53], "RMS" }, null);
 	private ChoiceGroup download = new ChoiceGroup(MahoMapsApp.text[54], Choice.MULTIPLE,
-			new String[] { MahoMapsApp.text[17] }, null);
+			new String[] { MahoMapsApp.text[17], "Upscale existing cache before downloading" }, null);
 	private ChoiceGroup proxyUsage = new ChoiceGroup(MahoMapsApp.text[19], Choice.MULTIPLE,
 			new String[] { MahoMapsApp.text[156], MahoMapsApp.text[157], }, null);
 	private TextField proxyServer = new TextField(MahoMapsApp.text[158], "", 256, TextField.URL);
@@ -72,6 +72,7 @@ public class SettingsScreen extends Form implements CommandListener {
 		tileInfo.setSelectedIndex(Settings.drawDebugInfo ? 1 : 0, true);
 		cache.setSelectedIndex(Settings.cacheMode, true);
 		download.setSelectedIndex(0, Settings.allowDownload);
+		download.setSelectedIndex(1, Settings.readCachedBeforeDownloading);
 		proxyUsage.setSelectedIndex(0, Settings.proxyTiles);
 		proxyUsage.setSelectedIndex(1, Settings.proxyApi);
 		uiSize.setSelectedIndex(Settings.uiSize, true);
@@ -103,6 +104,7 @@ public class SettingsScreen extends Form implements CommandListener {
 		Settings.drawDebugInfo = tileInfo.getSelectedIndex() == 1;
 		Settings.cacheMode = cache.getSelectedIndex();
 		Settings.allowDownload = download.isSelected(0);
+		Settings.readCachedBeforeDownloading = download.isSelected(1);
 		Settings.proxyTiles = proxyUsage.isSelected(0);
 		Settings.proxyApi = proxyUsage.isSelected(1);
 		Settings.uiSize = uiSize.getSelectedIndex();


### PR DESCRIPTION
One of "how we lived without it" features.
If there is no internet, loads higher zooms by upscaling lower ones. It's useless because lower zooms won't have information you need, but now the app at least won't leave you with clean gray screen if you have only the 15th level cached but wants to see the 16th.